### PR TITLE
Fix `mergeFiles` keeps file open and reduce thread number

### DIFF
--- a/src/core/live_downloader.ts
+++ b/src/core/live_downloader.ts
@@ -48,7 +48,7 @@ class LiveDownloader {
     finishedTasks: Task[] = [];
     droppedTasks: Task[] = [];
     outputFiles: OutputItem[] = [];
-    maxRunningThreads = 16;
+    maxRunningThreads = 10;
     nowRunningThreads = 0;
     stopFlag = false;
     finishFlag = false;

--- a/src/utils/download_files.ts
+++ b/src/utils/download_files.ts
@@ -2,7 +2,7 @@ import { Downloader as ShuaDownloader } from 'shua';
 const download = (urls: string[], output: string, config?) => {
     return new Promise((resolve, reject) => {
         const downloader = new ShuaDownloader({
-            threads: 16,
+            threads: 10,
             output,
             ascending: true,
             ...config

--- a/src/utils/exec_command.ts
+++ b/src/utils/exec_command.ts
@@ -1,18 +1,18 @@
 const exec = require('child_process').exec;
-const execCommand = (command: string, slient: boolean = false) => {
+const execCommand = (command: string, silent: boolean = false) => {
     return new Promise((resolve, reject) => {
         let child = exec(command);
         child.stdout.on('data', (data) => {
-            !slient && console.log(data);
+            !silent && console.log(data);
         });
         child.stderr.on('data', (data) => {
-            !slient && console.log(data);
+            !silent && console.log(data);
         });
         child.on('close', (code, signal) => {
             if (code === 0) {
                 resolve();
             } else {
-                !slient && console.error(code, signal);
+                !silent && console.error(code, signal);
                 reject();
             }
         }); 

--- a/src/utils/merge_files.ts
+++ b/src/utils/merge_files.ts
@@ -22,6 +22,7 @@ export default function mergeFiles(fileList = [], output = "./output.ts") {
                     if (i > lastIndex) {
                         bar.update(i);
                         bar.stop();
+                        writeStream.end();
                         resolve();
                     }
                 });


### PR DESCRIPTION
`mergeFiles` doesn't close the `writeStream` which causes `deleteDirectory` to fail because video.mp4/audio.mp4 is still occupied.

Also reduce the thread number to 10.
In my testing using 16 will constantly fail on downloading audio files (401 unauthorized). 10 seems to work fine.